### PR TITLE
Improve error handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "md-insights-client"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
     { name="Darren Spruell", email="darren.spruell@opswat.com" },
 ]

--- a/src/md_insights_client/insights_query.py
+++ b/src/md_insights_client/insights_query.py
@@ -378,7 +378,10 @@ def cli():
         parser.error(f"unable to load specified configuration: {e}")
 
     log_level = args.log_level or settings.log_level
-    logging.getLogger().setLevel(log_level.upper())
+    try:
+        logging.getLogger().setLevel(log_level.upper())
+    except ValueError as e:
+        parser.error(f"unable to set specified logging level: {e}")
 
     if log_level == "debug":
         from copy import deepcopy

--- a/src/md_insights_client/insights_snapshot.py
+++ b/src/md_insights_client/insights_snapshot.py
@@ -183,7 +183,10 @@ def cli():
         parser.error(f"unable to load specified configuration: {e}")
 
     log_level = args.log_level or settings.log_level
-    logging.getLogger().setLevel(log_level.upper())
+    try:
+        logging.getLogger().setLevel(log_level.upper())
+    except ValueError as e:
+        parser.error(f"unable to set specified logging level: {e}")
 
     if log_level == "debug":
         from copy import deepcopy

--- a/src/md_insights_client/settings.py
+++ b/src/md_insights_client/settings.py
@@ -49,5 +49,10 @@ class SettingsLoader:
         self.config_dict["conf_file"] = str(self.conf_file)
         self.config = SimpleNamespace(**self.config_dict)
 
+        # Set an explicit default logging level if absent in the
+        # configuration
+        if not getattr(self.config, "log_level", None):
+            self.config.log_level = DEFAULT_LOGLEVEL
+
     def get_config(self):
         return self.config

--- a/tox.ini
+++ b/tox.ini
@@ -25,4 +25,4 @@ skip_install = true
 deps =
     flake8
 commands =
-    flake8 {posargs:src}
+    flake8 --ignore E203,E501 {posargs:src}


### PR DESCRIPTION
Update client to improve error handling.

- Allow configuration to omit `log_level` (use default in the config object)
- Add error handling for misspelled log levels

Testing OK:

```
  format: OK (0.18=setup[0.03]+cmd[0.15] seconds)
  lint: OK (0.28=setup[0.00]+cmd[0.27] seconds)
  py39: OK (1.11=setup[1.00]+cmd[0.11] seconds)
  py310: OK (0.95=setup[0.84]+cmd[0.11] seconds)
  py311: OK (0.90=setup[0.79]+cmd[0.11] seconds)
  py312: OK (0.94=setup[0.82]+cmd[0.11] seconds)
  py313: OK (1.09=setup[0.95]+cmd[0.14] seconds)
  congratulations :) (5.48 seconds)
```

Fixes #2.