### PR TITLE
Implement tabular output for API lookup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,19 @@ To use this command, provide multiple positional arguments to the script.
 
 - The first argument is the **query type**, such as `c2-dns`, `c2-ip`,
   `reputation` or `all`. The special `all` type autodetects the artifact
-  format(s) to query the correct collections.
+  format(s) to query all relevant collections.
 - The second and subsequent arguments are the artifacts for which to query.
-  One or more artifacts such as an IP address or domain name may be specified.
+  One or more artifacts such as IP addresses or domain names may be specified.
 
 For example:
 
 ```
 md-insights-query-client all appleprocesshub.com apimonger.com
 ```
+
+By default, response data is output in tabular format, one indicator per row
+that is found in MD InSights collections. If you prefer to see the raw JSON
+response format from the API, use the `-j/--json` option.
 
 ### md-insights-snapshot-client
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "md-insights-client"
-version = "0.2.1"
+version = "0.3.0"
 authors = [
     { name="Darren Spruell", email="darren.spruell@opswat.com" },
 ]
@@ -13,6 +13,7 @@ readme = "README.md"
 dependencies = [
     "PyYAML==6.0.2",
     "requests==2.32.3",
+    "tabulate==0.9.0",
 ]
 classifiers = [
     # "Development Status :: 3 - Alpha",

--- a/src/md_insights_client/insights_query.py
+++ b/src/md_insights_client/insights_query.py
@@ -8,6 +8,8 @@ import logging
 import re
 from argparse import ArgumentParser
 from importlib.metadata import version
+from ipaddress import ip_address
+from tabulate import tabulate
 from typing import List, Union
 
 import requests
@@ -43,8 +45,11 @@ def _chunks(lst, n):
 
 def _is_ip_address(artifact: str) -> bool:
     """Check if artifact is an IP address."""
-    ip_pattern = r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
-    return bool(re.match(ip_pattern, artifact))
+    try:
+        ip_address(artifact)
+        return True
+    except ValueError:
+        return False
 
 
 def _is_domain_name(artifact: str) -> bool:
@@ -94,7 +99,7 @@ def _merge_results(
 
 
 def c2_dns_query(api_key: str, artifacts: Union[str, List[str]]) -> dict:
-    """Query the InSights API to determine if domain names are C&C endpoints.
+    """Query the InSights API to determine if domain names are C2 endpoints.
 
     Arguments:
     - api_key: MD InSights API key provisioned by OPSWAT.
@@ -134,7 +139,7 @@ def c2_dns_query(api_key: str, artifacts: Union[str, List[str]]) -> dict:
 
 
 def c2_ip_query(api_key: str, artifacts: Union[str, List[str]]) -> dict:
-    """Query the InSights API to determine if IP addresses are C&C endpoints.
+    """Query the InSights API to determine if IP addresses are C2 endpoints.
 
     Arguments:
     - api_key: MD InSights API key provisioned by OPSWAT.
@@ -301,6 +306,12 @@ def cli():
         help="configuration file path (default: %(default)s)",
     )
     parser.add_argument(
+        "-j",
+        "--json",
+        action="store_true",
+        help="output raw JSON data from API response",
+    )
+    parser.add_argument(
         "-l",
         "--log-level",
         choices=CHOICE_LOG_LEVELS,
@@ -400,18 +411,124 @@ def cli():
     try:
         if args.query_type == "c2-dns":
             result = c2_dns_query(settings.api_key, args.artifacts)
+            headers = ["artifact", "details"]
+            data = []
+            if result["details"]:
+                data.append(headers)
+                for artifact, details in result["details"].items():
+                    data.append([artifact, details])
         elif args.query_type == "c2-ip":
             result = c2_ip_query(settings.api_key, args.artifacts)
+            headers = ["artifact"]
+            data = []
+            if result["details"]:
+                for artifact, details in result["details"].items():
+                    rowdata = [artifact]
+                    dfields = details.keys()
+                    if "asn" in dfields:
+                        if details.get("asn"):
+                            headers.append("asn")
+                            rowdata.append(details["asn"])
+                    if "country" in dfields:
+                        if details.get("country"):
+                            headers.append("country")
+                            rowdata.append(details["country"])
+                    headers.append("description")
+                    rowdata.append(details["description"])
+                    data.append(rowdata)
+                data.insert(0, headers)
         elif args.query_type == "reputation":
             result = reputation_query(
                 settings.api_key, args.artifacts, args.max_batch_size
             )
+            headers = [
+                "artifact",  # artifact name
+                "score",  # score (int)
+                "src_count",  # alarmed/evaluated
+                "inquest",  # bool
+                "opswat",  # bool
+                "rep_srcs",  # list of sources (combined)
+            ]
+            data = []
+            for artifact, details in result["records"].items():
+                if details["sources_alarmed"] != 0:
+                    srcs = []
+                    rowdata = [artifact]
+                    rowdata.append(details["score"])
+                    src_count = (
+                        f'{details["sources_alarmed"]}'
+                        f'/{details["sources_evaluated"]}'
+                    )
+                    rowdata.append(src_count)
+                    for ds in ("inquest", "opswat"):
+                        if details["report"][ds].get("hits"):
+                            rowdata.append("Y")
+                            srcs.extend(details["report"][ds]["sources"])
+                        else:
+                            rowdata.append("N")
+                    rowdata.append(", ".join(srcs))
+                    data.append(rowdata)
+            if data:
+                data.insert(0, headers)
         elif args.query_type == "all":
             result = all_query(
                 settings.api_key, args.artifacts, args.max_batch_size
             )
+            headers = [
+                "artifact",  # artifact name
+                "score",  # score (int)
+                "rep",  # reputation hit (bool)
+                "c2",  # c2 hit (bool)
+                "src_count",  # alarmed/evaluated
+                "inquest",  # bool
+                "opswat",  # bool
+                "rep_srcs",  # list of sources (combined)
+                "c2_desc",  # C2 description
+            ]
+            data = []
+            for artifact, details in result["results"].items():
+                if details["c2"] or details["reputation"]["score"] != 0:
+                    srcs = []
+                    rowdata = [artifact]
+                    rep_score = details["reputation"]["score"]
+                    if isinstance(details["c2"], str):
+                        c2_details = details["c2"]
+                    elif isinstance(details["c2"], dict):
+                        c2_details = details["c2"].get("description")
+                    else:
+                        logging.warning(
+                            "artifact C2 field contains unexpected data: %s",
+                            details.get("c2"),
+                        )
+                        c2_details = None
+                    rowdata.append(rep_score)
+                    src_count = (
+                        f'{details["reputation"]["sources_alarmed"]}'
+                        f'/{details["reputation"]["sources_evaluated"]}'
+                    )
+                    rep_hit = "Y" if rep_score else "N"
+                    c2_hit = "Y" if c2_details else "N"
+                    rowdata.append(rep_hit)
+                    rowdata.append(c2_hit)
+                    rowdata.append(src_count)
+                    for ds in ("inquest", "opswat"):
+                        if details["reputation"]["report"][ds].get("hits"):
+                            rowdata.append("Y")
+                            srcs.extend(
+                                details["reputation"]["report"][ds]["sources"]
+                            )
+                        else:
+                            rowdata.append("N")
+                    rowdata.append(", ".join(srcs))
+                    rowdata.append(c2_details)
+                    data.append(rowdata)
+            if data:
+                data.insert(0, headers)
 
-        print(json.dumps(result, indent=2))
-
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            if data:
+                print(tabulate(data, headers="firstrow"))
     except (ConfigurationError, FeedAccessError, ValueError) as e:
         parser.error(f"Error attempting to query API: {e}")


### PR DESCRIPTION
Add support for a default human-readable tabular output for API indicator lookups. Add `-j/--json` option to revert to instead display the raw JSON response as previously implemented.

Replace IP address format validation with use of the ipaddress module.

Closes #3.

```
  format: OK (0.43=setup[0.08]+cmd[0.35] seconds)
  lint: OK (0.32=setup[0.01]+cmd[0.31] seconds)
  py39: OK (1.89=setup[1.69]+cmd[0.20] seconds)
  py310: OK (1.70=setup[1.52]+cmd[0.18] seconds)
  py311: OK (1.48=setup[1.31]+cmd[0.17] seconds)
  py312: OK (1.65=setup[1.47]+cmd[0.18] seconds)
  py313: OK (1.61=setup[1.42]+cmd[0.19] seconds)
  congratulations :) (9.15 seconds)
```