### PR TITLE
Fix KeyError exceptions in parsing API response

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "md-insights-client"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
     { name="Darren Spruell", email="darren.spruell@opswat.com" },
 ]


### PR DESCRIPTION
- Add better error handling around accessing data in API response
- Ensure JSON data can be dumped independent of any response parsing issues

Testing:

```
% md-insights-query-client -j all 156.238.237.180 103.68.195.138
{
  "results": {
  ...
  },
  "summary": {
    "total_artifacts": 2,
    "reputation_queries": 2,
    "c2_queries": 2
  }
}
```

Fixes #6.